### PR TITLE
replaced "GNU Linux" with "GNU/Linux"

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,7 +74,7 @@
                         <hr>
                     
                     
-                        <p>Run Android applications on any GNU Linux operating system.</p>
+                        <p>Run Android applications on any GNU/Linux operating system.</p>
                     
                     
                         <a href="#about" class="btn btn-primary btn-xl page-scroll">Find out more</a>
@@ -90,7 +90,7 @@
                         <hr class="light">
                         <p>
                             Anbox puts the Android operating system into a container, abstracts
-                            hardware access and integrates core system services into a GNU Linux
+                            hardware access and integrates core system services into a GNU/Linux
                             system. Every Android application will behave integrated into your
                             operating system like any other native application.
                         </p>


### PR DESCRIPTION
When you write "GNU Something", that means "Something" is a part of the GNU project. Although Linux is a free software, but it's not a part of the GNU project. For meaning the "GNU and Linux" operating system, write, "GNU/Linux". For more info on it, https://www.gnu.org/gnu/gnu-linux-faq.html#whyslash