### PR TITLE
Fix Minor Typos

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,18 +99,18 @@ if (!doNotTrack) {
         <header>
             <div class="header-content">
                 <div class="header-content-inner">
-                    
+
                         <h1>Android in a Box</h1>
-                    
-                    
+
+
                         <hr>
-                    
-                    
+
+
                         <p>Run Android applications on any GNU/Linux operating system.</p>
-                    
-                    
+
+
                         <a href="#about" class="btn btn-primary btn-xl page-scroll">Find out more</a>
-                    
+
                 </div>
             </div>
         </header>
@@ -151,7 +151,7 @@ if (!doNotTrack) {
         </section>
 
         <section id="features" style="padding: 50px 0;">
-            
+
                 <div class="container">
                     <div class="row">
                         <div class="col-lg-12 text-center">
@@ -160,77 +160,77 @@ if (!doNotTrack) {
                         </div>
                     </div>
                 </div>
-            
+
             <div class="container">
                 <div class="row">
-                    
+
                     <div class="col-lg-2 col-md-4 text-center">
                         <div class="service-box">
                             <i class="fa fa-4x fa-github wow bounceIn text-primary"></i>
                             <h3>Open Source</h3>
-                            
+
                                 <p class="text-muted">The whole source code is available as Open Source and licensed under the terms of the Apache and GPLv3 license.
 </p>
-                            
+
                         </div>
                     </div>
-                    
+
                     <div class="col-lg-2 col-md-4 text-center">
                         <div class="service-box">
                             <i class="fa fa-4x fa-laptop wow bounceIn text-primary"></i>
                             <h3>No limits</h3>
-                            
+
                                 <p class="text-muted">As Anbox is running an entire Android system, conceptually any application can run.
 </p>
-                            
+
                         </div>
                     </div>
-                    
+
                     <div class="col-lg-2 col-md-4 text-center">
                         <div class="service-box">
                             <i class="fa fa-4x fa-lock wow bounceIn text-primary"></i>
                             <h3>Secure</h3>
-                            
+
                                 <p class="text-muted">Anbox puts Android apps into a tightly sealed box without direct access to hardware or your data.
 </p>
-                            
+
                         </div>
                     </div>
-                    
+
                     <div class="col-lg-2 col-md-4 text-center">
                         <div class="service-box">
                             <i class="fa fa-4x fa-clock-o wow bounceIn text-primary"></i>
                             <h3>Performant</h3>
-                            
+
                                 <p class="text-muted">Runs Android without hardware virtualization and seamlessly bridges over hardware acceleration features.
 </p>
-                            
+
                         </div>
                     </div>
-                    
+
                     <div class="col-lg-2 col-md-4 text-center">
                         <div class="service-box">
                             <i class="fa fa-4x fa-microchip wow bounceIn text-primary"></i>
                             <h3>Integrated</h3>
-                            
+
                                 <p class="text-muted">Tightly integrated with the host operating system to offer a rich feature set.
 </p>
-                            
+
                         </div>
                     </div>
-                    
+
                     <div class="col-lg-2 col-md-4 text-center">
                         <div class="service-box">
                             <i class="fa fa-4x fa-microchip wow bounceIn text-primary"></i>
                             <h3>Convergent</h3>
-                            
+
                                 <p class="text-muted">Anbox scales across different form factors similar like
 Android does. It works on a laptop and a mobile phone.
 </p>
-                            
+
                         </div>
                     </div>
-                    
+
                 </div>
             </div>
         </section>
@@ -416,7 +416,7 @@ Android does. It works on a laptop and a mobile phone.
                             easy distribution to our users, as well as regular and fast updates.
                             <a target="_blank" href="http://flatpak.org/">Flatpak</a>
                             would be another alternative but we didn't investigate this yet, nor
-                            are we planing to do so in the near future. However, we're happy to
+                            are we planning to do so in the near future. However, we're happy to
                             accept contributions from the community around Anbox to provide necessary
                             changes to distribute Anbox as a flatpak package too.
                         </p>


### PR DESCRIPTION
Was just going through the Anbox site and saw a typo.

* planing → planning
* Removes trailing whitespace.